### PR TITLE
Phil edits

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -1,5 +1,5 @@
-Reference
-=========
+Client
+======
 
 .. autoclass:: fl33t.Fl33tClient
     :members:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,7 +14,7 @@ Testing
 -------
 
 Once you have written your new feature into the module, and have created a
-test for it, you need to run the test. In order to run the tests, you must
+test for it, please run the test. In order to run tests, you must
 have tox_ installed::
 
      pip install tox
@@ -23,7 +23,7 @@ Then you can run it by simply typing::
 
      tox
 
-Tox will create a virtual environment specifically for the testing, so if you
+Tox will create a virtual environment specifically for testing, so if you
 have added requirements, ensure that they are listed in the `requirements.txt`
 file and in the setup for distribution.
 
@@ -35,8 +35,8 @@ If it is a requirement only for testing, it should be listed in the
 Documentation
 -------------
 
-You do not need to create a virtual environment with all the of the fl33t
-dependencies to do documentation. Install the requirements listed in the
+You do not need to create a virtual environment with all of the fl33t
+dependencies to update documentation. Install the requirements listed in the
 `requirements-docs.txt` file, and make your documentation changes. To
 preview the documentation, run::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,13 +1,13 @@
 Getting Started
 ===============
 
-You must already have a valid fl33t account, in order to use this client.
+In order to use this client, you must already have a valid fl33t account.
 You will need to know the `team_id` assigned to you by fl33t, and you will
 need to create a session token within the fl33t console for you to use with
-this client. Various privilege levels are available, most non-informational
+this client. Various privilege levels are available. Most non-informational
 interactions will require that the session token have `admin` privileges, but
 the selection of the specific privilege to assign to this new session token are
-left up to the reader.
+left up to you.
 
 Basic Tutorial
 --------------

--- a/fl33t/client.py
+++ b/fl33t/client.py
@@ -1,5 +1,5 @@
 """
-Fl33t Client
+fl33t Client
 ============
 
 The main client class that is used to interact with fl33t.
@@ -38,9 +38,9 @@ ENDPOINT_FAILED_MSG = 'The fl33t endpoint for {} returned an invalid response'
 
 class Fl33tClient:  # pylint: disable=too-many-public-methods
     """
-    Handles all Fl33t-related interactions.
+    Handles all fl33t-related interactions.
 
-    Fl33t is used for managing firmware build trains.
+    fl33t is used for managing firmware build trains.
 
     REST API docs: https://www.fl33t.com/docs/rest
     """
@@ -165,7 +165,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
 
     def generate_id_string(self, length=None):
         """
-        Generate random string for use in Fl33t ids.
+        Generate random string for use in fl33t ids.
 
         :param length: The length of the returned random string. If not
             provided, it defaults to the value of
@@ -438,7 +438,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
 
     def get_device(self, device_id):
         """
-        Get a device by ID from Fleet.
+        Get a device by ID from fl33t.
 
         :param str device_id: The device ID to retrieve information for
         :returns: :py:class:`fl33t.models.Device`

--- a/fl33t/client.py
+++ b/fl33t/client.py
@@ -593,7 +593,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
 
     def list_builds(self, train_id, version=None, offset=None, limit=None):
         """
-        Get all builds from fl33t, by train id.
+        Get all builds from fl33t by train id.
 
         :param int train_id: The train_id that the builds are part of
         :param offset: If provided, the starting offset for result sets.

--- a/fl33t/exceptions.py
+++ b/fl33t/exceptions.py
@@ -6,7 +6,7 @@ All exceptions used by the fl33t client
 
 
 class DuplicateDeviceIdError(Exception):
-    """A device by that ID already exists in Fleet."""
+    """A device by that ID already exists in fl33t."""
     pass
 
 
@@ -16,27 +16,27 @@ class InvalidIdError(Exception):
 
 
 class InvalidFleetIdError(InvalidIdError):
-    """No fleet by that ID exists in Fleet."""
+    """No fleet by that ID exists in fl33t."""
     pass
 
 
 class InvalidBuildIdError(InvalidIdError):
-    """No build by that ID exists in Fleet."""
+    """No build by that ID exists in fl33t."""
     pass
 
 
 class InvalidTrainIdError(InvalidIdError):
-    """No train by that ID exists in Fleet."""
+    """No train by that ID exists in fl33t."""
     pass
 
 
 class InvalidDeviceIdError(InvalidIdError):
-    """No device by that ID exists in Fleet."""
+    """No device by that ID exists in fl33t."""
     pass
 
 
 class InvalidSessionIdError(InvalidIdError):
-    """No session by that ID exists in Fleet."""
+    """No session by that ID exists in fl33t."""
     pass
 
 

--- a/fl33t/exceptions.py
+++ b/fl33t/exceptions.py
@@ -50,7 +50,7 @@ class UnprivilegedToken(Exception):
 
 
 class Fl33tApiException(Exception):
-    """The Fl33t API returned an exception handling our request"""
+    """The fl33t API returned an exception handling our request"""
     pass
 
 

--- a/fl33t/models/base.py
+++ b/fl33t/models/base.py
@@ -1,7 +1,7 @@
 """
 BaseModel
 
-Has all common methods for Fl33t models
+Has all common methods for fl33t models
 """
 
 import datetime
@@ -16,7 +16,7 @@ from fl33t.utils import ExtendedEncoder
 
 
 class BaseModel(ABC):
-    """The base model from which all Fl33t models should be extended"""
+    """The base model from which all fl33t models should be extended"""
 
     _invalid_id = InvalidIdError
     _data = {}

--- a/fl33t/models/base.py
+++ b/fl33t/models/base.py
@@ -135,7 +135,7 @@ class BaseModel(ABC):
         """
         Update this object in fl33t
 
-        :returns: :py:class:`self`, on success or False, on update failure
+        :returns: :py:class:`self` on success, or False on update failure
         :raises UnprivilegedToken: if the session token does not have enough
             privilege to perform this action
         :raises Fl33tApiException: if there was a 5xx error returned by fl33t
@@ -161,7 +161,7 @@ class BaseModel(ABC):
         """
         Delete this object from a fl33t
 
-        :returns: True, on success or False, on failure
+        :returns: True on success, or False on failure
         :raises UnprivilegedToken: if the session token does not have enough
             privilege to perform this action
         :raises Fl33tApiException: if there was a 5xx error returned by fl33t

--- a/fl33t/models/build.py
+++ b/fl33t/models/build.py
@@ -17,7 +17,7 @@ from fl33t.utils import md5
 
 class Build(BaseModel, OneTrainMixin):
     """
-    The Fl33t Build model
+    The fl33t Build model
     """
 
     _invalid_id = InvalidBuildIdError

--- a/fl33t/models/build.py
+++ b/fl33t/models/build.py
@@ -121,7 +121,7 @@ class Build(BaseModel, OneTrainMixin):
         """
         Create this build record in fl33t and upload the new build file
 
-        :returns: :py:class:`self`, on success or False, on failure
+        :returns: :py:class:`self` on success, or False on failure
         :raises UnprivilegedToken: if the session token does not have enough
             privilege to perform this action
         :raises Fl33tApiException: if there was a 5xx error returned by fl33t

--- a/fl33t/models/device.py
+++ b/fl33t/models/device.py
@@ -2,7 +2,7 @@
 
 Models
 
-All the models in use by Fl33t
+All the models in use by fl33t
 
 """
 
@@ -22,7 +22,7 @@ from fl33t.models.mixins import (
 
 class Device(BaseModel, OneBuildMixin, OneFleetMixin):
     """
-    The Fl33t Device model
+    The fl33t Device model
     """
 
     invalid_id = InvalidDeviceIdError

--- a/fl33t/models/device.py
+++ b/fl33t/models/device.py
@@ -116,7 +116,7 @@ class Device(BaseModel, OneBuildMixin, OneFleetMixin):
         """
         Create this device in fl33t
 
-        :returns: :py:class:`self`, on success or False, on failure
+        :returns: :py:class:`self` on success, or False on failure
         :raises DuplicateDeviceIdError: if the device ID already exists
         :raises UnprivilegedToken: if the session token does not have enough
             privilege to perform this action

--- a/fl33t/models/fleet.py
+++ b/fl33t/models/fleet.py
@@ -2,7 +2,7 @@
 
 Models
 
-All the models in use by Fl33t
+All the models in use by fl33t
 
 """
 
@@ -16,7 +16,7 @@ from fl33t.models.mixins import (
 
 
 class Fleet(BaseModel, OneTrainMixin, OneBuildMixin, ManyDevicesMixin):
-    """The Fl33t Fleet model"""
+    """The fl33t Fleet model"""
 
     _invalid_id = InvalidFleetIdError
 

--- a/fl33t/models/mixins.py
+++ b/fl33t/models/mixins.py
@@ -1,7 +1,7 @@
 """
 Mixins
 
-Reusable pieces for Fl33t models
+Reusable pieces for fl33t models
 """
 
 

--- a/fl33t/models/session.py
+++ b/fl33t/models/session.py
@@ -2,7 +2,7 @@
 
 Models
 
-All the models in use by Fl33t
+All the models in use by fl33t
 
 """
 
@@ -11,7 +11,7 @@ from fl33t.models.base import BaseModel
 
 
 class Session(BaseModel):
-    """The Fl33t Session model"""
+    """The fl33t Session model"""
 
     _invalid_id = InvalidSessionIdError
     _booleans = ['admin', 'device', 'provisioning', 'readonly', 'upload']
@@ -27,7 +27,7 @@ class Session(BaseModel):
     }
 
     def priv(self):
-        """Return a human readable privilege"""
+        """Return a human-readable privilege"""
         if self.admin:
             return 'admin'
         if self.device:

--- a/fl33t/models/train.py
+++ b/fl33t/models/train.py
@@ -16,7 +16,7 @@ from fl33t.models.mixins import (
 
 class Train(BaseModel, ManyFleetsMixin, ManyBuildsMixin):
     """
-    The Fl33t Train model
+    The fl33t Train model
     """
 
     _invalid_id = InvalidTrainIdError


### PR DESCRIPTION
I edited .rst files and comments in .py files in order to update the documentation generated from the code that lives at https://fl33t.readthedocs.io/en/latest/getting_started.html.

One change made throughout the documentation:
* Used `fl33t` to refer to the service (rather than `Fleet` or `Fl33t1`)

Otherwise, a few little things (primarily a comma splice in getting_started.rst). Thanks!