### PR TITLE
Incorporate fl33t API updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Retrieve all trains/fleets/devices and if there are any upgrades pending::
             print(fleet)
             for device in fleet.devices():
                 print(device)
-                fw_upgrade = device.upgrade_available()
+                fw_upgrade = device.checkin()
                 if fw_upgrade:
                     print(fw_upgrade)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,7 +26,7 @@ Then list all trains, fleets and devices in your account::
             print(fleet)
             for device in fleet.devices():
                 print(device)
-                fw_upgrade = device.upgrade_available()
+                fw_upgrade = device.checkin()
                 if fw_upgrade:
                     print(fw_upgrade)
 

--- a/fl33t/client.py
+++ b/fl33t/client.py
@@ -322,7 +322,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         url = "/".join((self.base_team_url, 'sessions'))
         params = self._build_offset_limit(offset=offset, limit=limit)
 
-        single_page = False if offset is None else True
+        single_page = False if offset is None and limit is None else True
         return self._paginator(
             single_page,
             url,
@@ -398,11 +398,10 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         raise Fl33tApiException(ENDPOINT_FAILED_MSG.format(
             'fleet retrieval'))
 
-    def get_build(self, train_id, build_id):
+    def get_build(self, build_id):
         """
         Return information about a specific build
 
-        :param str train_id: The train ID that owns the provided build ID
         :param str build_id: The build ID to retrieve information for
         :returns: :py:class:`fl33t.models.Build`
         :raises InvalidBuildIdError: if the build does not exist
@@ -411,13 +410,13 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         :raises Fl33tApiException: if there was a 5xx error returned by fl33t
         """
 
-        url = "/".join((self.base_team_url, 'train/{}/build/{}'.format(
-            train_id, build_id)))
+        url = "/".join((self.base_team_url, 'build/{}'.format(
+            build_id)))
 
         result = self.get(url)
 
         if result.status_code in (400, 404):
-            raise InvalidBuildIdError('train={}:{}'.format(train_id, build_id))
+            raise InvalidBuildIdError(build_id)
 
         if 'build' in result.json():
             build = result.json()['build']
@@ -543,7 +542,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         if train_id:
             params['train_id'] = train_id
 
-        single_page = False if offset is None else True
+        single_page = False if offset is None and limit is None else True
         return self._paginator(
             single_page,
             url,
@@ -574,7 +573,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         url = "/".join((self.base_team_url, 'trains'))
         params = self._build_offset_limit(offset=offset, limit=limit)
 
-        single_page = False if offset is None else True
+        single_page = False if offset is None and limit is None else True
         return self._paginator(
             single_page,
             url,
@@ -610,7 +609,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         if fleet_id:
             params['fleet_id'] = fleet_id
 
-        single_page = False if offset is None else True
+        single_page = False if offset is None and limit is None else True
         return self._paginator(
             single_page,
             url,
@@ -639,13 +638,13 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         :raises Fl33tApiException: if there was a 5xx error returned by fl33t
         """
 
-        url = "/".join((self.base_team_url, 'train/{}/builds'.format(
-            train_id)))
+        url = "/".join((self.base_team_url, 'builds'))
         params = self._build_offset_limit(offset=offset, limit=limit)
+        params['train_id'] = train_id
         if version:
             params['version'] = version
 
-        single_page = False if offset is None else True
+        single_page = False if offset is None and limit is None else True
         return self._paginator(
             single_page,
             url,

--- a/fl33t/client.py
+++ b/fl33t/client.py
@@ -5,6 +5,7 @@ fl33t Client
 The main client class that is used to interact with fl33t.
 """
 
+import json
 import logging
 import random
 import string
@@ -479,7 +480,7 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         raise Fl33tApiException(ENDPOINT_FAILED_MSG.format(
             'device retrieval'))
 
-    def has_upgrade_available(self, device_id, currently_installed_id=None):
+    def device_checkin(self, device_id, currently_installed_id=None):
         """
         Does this device have pending firmware updates?
 
@@ -493,16 +494,18 @@ class Fl33tClient:  # pylint: disable=too-many-public-methods
         :raises Fl33tApiException: if there was a 5xx error returned by fl33t
         """
 
-        url = '/'.join((self.base_team_url, 'device/{}/build'.format(
+        url = '/'.join((self.base_team_url, 'device/{}/checkin'.format(
             device_id)))
 
-        params = None
+        checkin = {}
         if currently_installed_id:
-            params = {
-                'installed_build_id': currently_installed_id
-            }
+            checkin['build_id'] = currently_installed_id
 
-        result = self.get(url, params=params)
+        body = {
+            'checkin': checkin
+        }
+
+        result = self.post(url, data=json.dumps(body))
 
         # No update available.
         if result.status_code == 204:

--- a/fl33t/models/build.py
+++ b/fl33t/models/build.py
@@ -116,9 +116,7 @@ class Build(BaseModel, OneTrainMixin):
 
         return '/'.join((
             self._client.base_team_url,
-            'train/{}/build'.format(
-                self.train_id
-            )
+            'build'
         ))
 
     def create(self):

--- a/fl33t/models/device.py
+++ b/fl33t/models/device.py
@@ -57,7 +57,7 @@ class Device(BaseModel, OneBuildMixin, OneFleetMixin):
 
         return self.device_id
 
-    def upgrade_available(self, installed_build_id=None):
+    def checkin(self, installed_build_id=None):
         """
         Returns the available firmware update, if there is one
 
@@ -78,7 +78,7 @@ class Device(BaseModel, OneBuildMixin, OneFleetMixin):
         if not installed_build_id and self.build_id:
             installed_build_id = self.build_id
 
-        return self._client.has_upgrade_available(
+        return self._client.device_checkin(
             self.device_id,
             currently_installed_id=installed_build_id
         )

--- a/fl33t/models/mixins.py
+++ b/fl33t/models/mixins.py
@@ -37,16 +37,7 @@ class OneBuildMixin:  # pylint: disable=too-few-public-methods
             return None
 
         if not self._build or self.build_id != self._build.build_id:
-            if hasattr(self, 'fleet') and self.fleet.train_id:
-                train_id = self.fleet.train_id
-
-            elif hasattr(self, 'train_id') and self.train_id:
-                train_id = self.train_id
-
-            else:
-                return None
-
-            self._build = self._client.get_build(train_id, self.build_id)
+            self._build = self._client.get_build(self.build_id)
 
         return self._build
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 name = 'fl33t'
 description = 'Fl33t API Client'
-version = '0.5.0'
+version = '0.6.0'
 author = 'Fictive Kin LLC'
 email = 'hello@fictivekin.com'
 classifiers = [

--- a/tests/client/test_builds.py
+++ b/tests/client/test_builds.py
@@ -29,8 +29,6 @@ def test_get_build(fl33t_client):
 
     url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build',
         build_id
     ))
@@ -38,7 +36,7 @@ def test_get_build(fl33t_client):
     with requests_mock.Mocker() as mock:
         mock.get(url, text=json.dumps(build_response))
 
-        obj = fl33t_client.get_build(train_id, build_id)
+        obj = fl33t_client.get_build(build_id)
 
         assert isinstance(obj, Build)
         assert obj.train_id == train_id
@@ -46,12 +44,9 @@ def test_get_build(fl33t_client):
 
 def test_fail_get_build_invalid_id(fl33t_client):
     build_id = 'asdf'
-    train_id = 'fdsa'
 
     url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build',
         build_id
     ))
@@ -63,5 +58,5 @@ def test_fail_get_build_invalid_id(fl33t_client):
         ])
 
         with pytest.raises(InvalidBuildIdError):
-            fl33t_client.get_build(train_id, build_id)
-            fl33t_client.get_build(train_id, build_id)
+            fl33t_client.get_build(build_id)
+            fl33t_client.get_build(build_id)

--- a/tests/models/test_build.py
+++ b/tests/models/test_build.py
@@ -29,8 +29,6 @@ def test_create(fl33t_client, build_id, train_id):
 
     url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build'
     ))
 
@@ -48,12 +46,10 @@ def test_create(fl33t_client, build_id, train_id):
         assert response.build_id == build_id
 
 
-def test_delete(fl33t_client, build_id, train_id, build_get_response):
+def test_delete(fl33t_client, build_id, build_get_response):
 
     url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build',
         build_id
     ))
@@ -62,7 +58,7 @@ def test_delete(fl33t_client, build_id, train_id, build_get_response):
         mock.get(url, text=json.dumps(build_get_response))
         mock.delete(url, [{'status_code': 204}])
 
-        obj = fl33t_client.get_build(train_id, build_id)
+        obj = fl33t_client.get_build(build_id)
         assert obj.delete() is True
 
 
@@ -103,9 +99,7 @@ def test_list(fl33t_client, train_id):
 
     url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
-        'builds'
+        'builds?train_id={}'.format(train_id)
     ))
 
     with requests_mock.Mocker() as mock:
@@ -120,15 +114,13 @@ def test_list(fl33t_client, train_id):
         assert len(objs) == 2
 
 
-def test_update(fl33t_client, train_id, build_id, build_get_response):
+def test_update(fl33t_client, build_id, build_get_response):
 
     update_response = copy.copy(build_get_response)
     update_response['build']['released'] = True
 
     url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build',
         build_id
     ))
@@ -137,7 +129,7 @@ def test_update(fl33t_client, train_id, build_id, build_get_response):
         mock.get(url, text=json.dumps(build_get_response))
         mock.put(url, text=json.dumps(update_response), status_code=204)
 
-        obj = fl33t_client.get_build(train_id, build_id)
+        obj = fl33t_client.get_build(build_id)
         obj.released = True
 
         response = obj.update()

--- a/tests/models/test_device.py
+++ b/tests/models/test_device.py
@@ -166,16 +166,16 @@ def test_upgrade_available(fl33t_client,
         device_id
     ))
 
-    build_url = '/'.join((url, 'build'))
+    checkin_url = '/'.join((url, 'checkin'))
 
     with requests_mock.Mocker() as mock:
         mock.get(url, text=json.dumps(device_get_response))
-        mock.get(build_url, text=json.dumps(upgrade_response))
+        mock.post(checkin_url, text=json.dumps(upgrade_response))
 
         obj = fl33t_client.get_device(device_id)
         assert isinstance(obj, Device)
 
-        build = obj.upgrade_available()
+        build = obj.checkin()
         assert isinstance(build, Build)
         assert build.train_id == train_id
 
@@ -191,16 +191,16 @@ def test_upgrade_not_available(fl33t_client,
         device_id
     ))
 
-    build_url = '/'.join((url, 'build'))
+    checkin_url = '/'.join((url, 'checkin'))
 
     with requests_mock.Mocker() as mock:
         mock.get(url, text=json.dumps(device_get_response))
-        mock.get(build_url, status_code=204)
+        mock.post(checkin_url, status_code=204)
 
         obj = fl33t_client.get_device(device_id)
         assert isinstance(obj, Device)
 
-        build = obj.upgrade_available()
+        build = obj.checkin()
         assert isinstance(build, bool)
         assert build is False
 

--- a/tests/models/test_device.py
+++ b/tests/models/test_device.py
@@ -252,7 +252,6 @@ def test_parent_fleet(fl33t_client,
 def test_parent_build(fl33t_client,
                       device_id,
                       fleet_id,
-                      train_id,
                       build_id,
                       device_get_response,
                       fleet_get_response,
@@ -272,8 +271,6 @@ def test_parent_build(fl33t_client,
 
     build_url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build',
         build_id
     ))

--- a/tests/models/test_fleet.py
+++ b/tests/models/test_fleet.py
@@ -151,7 +151,6 @@ def test_parent_train(fl33t_client,
 
 def test_parent_build(fl33t_client,
                       fleet_id,
-                      train_id,
                       build_id,
                       fleet_get_response,
                       build_get_response):
@@ -164,8 +163,6 @@ def test_parent_build(fl33t_client,
 
     build_url = '/'.join((
         fl33t_client.base_team_url,
-        'train',
-        train_id,
         'build',
         build_id
     ))


### PR DESCRIPTION
There have been a couple of fl33t REST API updates lately. The old URLs are still supported, but deprecated. This PR updates fl33t-client to use the newer URLs.

 - The build URLs were moved to the top level instead of being nested beneath /train/<train_id>. This was motivated by ergonomics: the client may want to get information about a build without having the train_id handy.
 - The check for updates has been changed to a more generic checkin POST. This will allow for the addition of new features on our roadmap that include the device sending and receiving more data during each checkin.